### PR TITLE
Add write and word list config filters

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -162,8 +162,6 @@ limit_scrapers = false
 
 [authorization]
 word_whitelist = [
-  "olympics2024",
-  "paris2024",
 ]
 
 # Pubkey addresses in this array are whitelisted for event publishing.
@@ -179,6 +177,19 @@ pubkey_whitelist = [
 ]
 
 pubkey_whitelist_readers = [
+  # July 24 am
+  "40bdcc08888d98d49d03fb93bffd1cc46d9b8f187d08c9fc81b4adf0ad00fd2c",
+  "d12c4697332c1e7043c17dbc8391d70630b198f2eb8f7343597e8ba38ac21182",
+  "22e13d7bb2df6cc1b4c975296ead122fd97aa104167fd03e8c8137e556cdb56f",
+  "dcef2a8ab271e9db365c85b58f34988aee08f56f43c6fc934a667873c226132e",
+  "81c4d638dfec1beb4ecf0bd38b1619daa5f26a18c39d426d8b0b2228200bd5e4",
+  "de2494d0bbeb97a83f6efb211a909f9a6e1b60692153a6dd14174f0c1c5c469a",
+  "58b3070adbee964fd24c152d2840f81453e68eb6f1ed440be6d5086d45a38fd4",
+  "cf5caca51204e03d5723e41c4a7aac2f4bd770d8018a722ab8f10d361bd754f2",
+  "eaba7a49cdcc542942567ab92ec08d0622b538a34a1392fbbbdbc75697790a4d",
+  "7a117235267b09b67956eb98361e462165fa1af7ce2111347fb800cb7e176dc7",
+  "06b7819d7f1c7f5472118266ed7bca8785dceae09e36ea3a4af665c6d1d8327c",
+
   "0403c86a1bb4cfbc34c8a493fbd1f0d158d42dd06d03eaa3720882a066d3a378", # Global Sport Center
   "89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5", # Daniel
   "d0a1ffb8761b974cec4a3be8cbcb2e96a7090dcf465ffeac839aa4ca20c9a59e", # Matt

--- a/config.toml
+++ b/config.toml
@@ -161,10 +161,27 @@ reject_future_seconds = 1800
 limit_scrapers = false
 
 [authorization]
+word_whitelist = [
+  "olympics2024",
+  "paris2024",
+  "paris2024olympics",
+  "paris2024olympicgames",
+  "paris2024olympic",
+]
+
 # Pubkey addresses in this array are whitelisted for event publishing.
 # Only valid events by these authors will be accepted, if the variable
 # is set.
 pubkey_whitelist = [
+  "0403c86a1bb4cfbc34c8a493fbd1f0d158d42dd06d03eaa3720882a066d3a378", # Global Sport Center
+  "89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5", # Daniel
+  "d0a1ffb8761b974cec4a3be8cbcb2e96a7090dcf465ffeac839aa4ca20c9a59e", # Matt
+  "27cf2c68535ae1fc06510e827670053f5dcd39e6bd7e05f1ffb487ef2ac13549", # Josh
+  "76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa", # Rabble
+  "969e6a28ee5214cb0296ee69cbdce4f43229124a78b1043d85df31e5636d0f1f", # Linda
+]
+
+pubkey_whitelist_readers = [
   "0403c86a1bb4cfbc34c8a493fbd1f0d158d42dd06d03eaa3720882a066d3a378", # Global Sport Center
   "89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5", # Daniel
   "d0a1ffb8761b974cec4a3be8cbcb2e96a7090dcf465ffeac839aa4ca20c9a59e", # Matt

--- a/config.toml
+++ b/config.toml
@@ -164,9 +164,6 @@ limit_scrapers = false
 word_whitelist = [
   "olympics2024",
   "paris2024",
-  "paris2024olympics",
-  "paris2024olympicgames",
-  "paris2024olympic",
 ]
 
 # Pubkey addresses in this array are whitelisted for event publishing.

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,7 +80,9 @@ pub struct Limits {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(unused)]
 pub struct Authorization {
+    pub word_whitelist: Option<Vec<String>>, // If present, only allow event contents that contain these words
     pub pubkey_whitelist: Option<Vec<String>>, // If present, only allow these pubkeys to publish events
+    pub pubkey_whitelist_readers: Option<Vec<String>>, // List of pubkeys that can read this relay
     pub nip42_auth: bool,                      // if true enables NIP-42 authentication
     pub nip42_dms: bool, // if true send DMs only to their authenticated recipients
 }
@@ -309,12 +311,14 @@ impl Default for Settings {
                 event_persist_buffer: 4096,
                 event_kind_blacklist: None,
                 event_kind_allowlist: None,
-                limit_scrapers: false
+                limit_scrapers: false,
             },
             authorization: Authorization {
-                pubkey_whitelist: None, // Allow any address to publish
-                nip42_auth: false,      // Disable NIP-42 authentication
-                nip42_dms: false,       // Send DMs to everybody
+                word_whitelist: None, // Words needed in the content to be able to publish to the relay
+                pubkey_whitelist: None, // Allow any pubkey from this list to publish
+                pubkey_whitelist_readers: None, // Allow any pubkey from this list to read
+                nip42_auth: false,    // Disable NIP-42 authentication
+                nip42_dms: false,     // Send DMs to everybody
             },
             pay_to_relay: PayToRelay {
                 enabled: false,

--- a/src/event.rs
+++ b/src/event.rs
@@ -472,12 +472,8 @@ mod tests {
         let mut event = Event::simple_event();
         event.tags = vec![vec!["e".to_owned(), "foo".to_owned()]];
         event.build_index();
-        assert!(
-            event.generic_tag_val_intersect(
-                'e',
-                &HashSet::from(["foo".to_owned(), "bar".to_owned()])
-            )
-        );
+        assert!(event
+            .generic_tag_val_intersect('e', &HashSet::from(["foo".to_owned(), "bar".to_owned()])));
     }
 
     #[test]


### PR DESCRIPTION
This separate the config filters into a read and write list. To write to need to be part of the write and read list. To read only to the read list. There's also a word list, if not empty, you need to add one of those words to the content of the event.

Example
```
["AUTH","e553c0a9-3738-49e1-b5db-2c1364471ab2"]
["AUTH",{"kind":22242,"id":"f2313a854ac6fcf7cf9087252817a13e8a504ceacc19693c49fc1bd28259c868","pubkey":"89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5","created_at":1721840057,"tags":[["relay","wss://olympics2024.nos.social"],["challenge","e553c0a9-3738-49e1-b5db-2c1364471ab2"]],"content":"","sig":"
a90edfe13615284c369eb3f04127d0c68a7a8e4192a6859c452ee8fb7373fd03d0b8a4a2fcf4408230d341454bc14e17c7c6c74ddd1966db4731d2d91f7b9e10"}]
["OK","f2313a854ac6fcf7cf9087252817a13e8a504ceacc19693c49fc1bd28259c868",true,""]
["EVENT",{"kind":1,"id":"3656c8b1ba3bcf05a80cd7230d3111df340420147560cfdf2e9fe5a8ea9e0afd","pubkey":"89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5","created_at":1721840226,"tags":[],"content":"hola","sig":"1c637b91607deb9af36b0be638c1c3e94a657195e74c4cee8893423d299c293eb71a7f841d8eca61920d136bbd4b1
fb0280c928602cc9bfb68b9b03b031e0d2a"}]
["OK","3656c8b1ba3bcf05a80cd7230d3111df340420147560cfdf2e9fe5a8ea9e0afd",false,"restricted: The event doesn't contain a keyword"]
["EVENT",{"kind":1,"id":"bb83f7f6f884e0971b431132433594e501c915427e599dcad89e21bf11d4dd1d","pubkey":"89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5","created_at":1721840267,"tags":[],"content":"hola paris2024","sig":"9d4ec88c4a2b09e9e55f6ce3a747f3856057e8772d241b46adec50b3f18b2034ba1cf8f186513deb5de
62b2c64841eb8a4133011f1b5015fcead3fa7a680ba95"}]
["OK","bb83f7f6f884e0971b431132433594e501c915427e599dcad89e21bf11d4dd1d",true,""]
```