### PR TITLE
Fix single note query

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -5,7 +5,6 @@ use tracing::{debug, trace};
 use uuid::Uuid;
 
 use crate::close::Close;
-use crate::config::Settings;
 use crate::conn::Nip42AuthState::{AuthPubkey, Challenge, NoAuth};
 use crate::error::Error;
 use crate::error::Result;
@@ -38,20 +37,18 @@ pub struct ClientConn {
     max_subs: usize,
     /// NIP-42 AUTH
     auth: Nip42AuthState,
-
-    settings: Settings,
 }
 
 impl Default for ClientConn {
     fn default() -> Self {
-        Self::new_with_default_settings("unknown".to_owned())
+        Self::new("unknown".to_owned())
     }
 }
 
 impl ClientConn {
     /// Create a new, empty connection state.
     #[must_use]
-    pub fn new(client_ip_addr: String, settings: Settings) -> Self {
+    pub fn new(client_ip_addr: String) -> Self {
         let client_id = Uuid::new_v4();
         ClientConn {
             client_ip_addr,
@@ -59,17 +56,7 @@ impl ClientConn {
             subscriptions: HashMap::new(),
             max_subs: 32,
             auth: NoAuth,
-            settings: settings,
         }
-    }
-
-    /// Create a new, empty connection state.
-    #[must_use]
-    pub fn new_with_default_settings(client_ip_addr: String) -> Self {
-        ClientConn::new(
-            client_ip_addr,
-            Settings::new(&None).expect("couldn't create Settings"),
-        )
     }
 
     #[must_use]

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -211,7 +211,10 @@ impl ClientConn {
                 match (relay.and_then(host_str), host_str(relay_url)) {
                     (Some(received_relay), Some(our_relay)) => {
                         if received_relay != our_relay {
-                            debug!("Invalid auth relay. Should be: {}", our_relay);
+                            debug!(
+                                "Invalid auth relay. Should be {} but was {}",
+                                our_relay, received_relay
+                            );
                             return Err(Error::AuthFailure);
                         }
                     }

--- a/src/repo/sqlite.rs
+++ b/src/repo/sqlite.rs
@@ -1016,7 +1016,8 @@ fn query_from_filter(f: &ReqFilter) -> (String, Vec<Box<dyn ToSql>>, Option<Stri
         let mut id_searches: Vec<String> = vec![];
         for id in idvec {
             id_searches.push("event_hash=?".to_owned());
-            params.push(Box::new(id.clone()));
+            let id_bin = hex::decode(id).ok();
+            params.push(Box::new(id_bin));
         }
         if idvec.is_empty() {
             // if the ids list was empty, we should never return

--- a/src/server.rs
+++ b/src/server.rs
@@ -1077,7 +1077,7 @@ async fn nostr_server(
     // get a broadcast channel for clients to communicate on
     let mut bcast_rx = broadcast.subscribe();
     // Track internal client state
-    let mut conn = conn::ClientConn::new(client_info.remote_ip, settings.clone());
+    let mut conn = conn::ClientConn::new(client_info.remote_ip);
     // subscription creation rate limiting
     let mut sub_lim_opt = None;
     // 100ms jitter when the rate limiter returns

--- a/tests/conn.rs
+++ b/tests/conn.rs
@@ -16,7 +16,7 @@ mod tests {
 
     #[test]
     fn test_generate_auth_challenge() {
-        let mut client_conn = ClientConn::new_with_default_settings("127.0.0.1".into());
+        let mut client_conn = ClientConn::new("127.0.0.1".into());
 
         assert_eq!(client_conn.auth_challenge(), None);
         assert_eq!(client_conn.auth_pubkey(), None);
@@ -45,7 +45,7 @@ mod tests {
 
         let mut settings = Settings::new(&None).unwrap();
         settings.authorization.pubkey_whitelist = Some(vec![pubkey.to_hex()]);
-        let mut client_conn = ClientConn::new("127.0.0.1".into(), settings);
+        let mut client_conn = ClientConn::new("127.0.0.1".into());
 
         assert_eq!(client_conn.auth_challenge(), None);
         assert_eq!(client_conn.auth_pubkey(), None);
@@ -67,7 +67,7 @@ mod tests {
 
     #[test]
     fn test_fail_to_authenticate_in_invalid_state() {
-        let mut client_conn = ClientConn::new_with_default_settings("127.0.0.1".into());
+        let mut client_conn = ClientConn::new("127.0.0.1".into());
 
         assert_eq!(client_conn.auth_challenge(), None);
         assert_eq!(client_conn.auth_pubkey(), None);
@@ -85,7 +85,7 @@ mod tests {
 
         let mut settings = Settings::new(&None).unwrap();
         settings.authorization.pubkey_whitelist = Some(vec![pubkey.to_hex()]);
-        let mut client_conn = ClientConn::new("127.0.0.1".into(), settings);
+        let mut client_conn = ClientConn::new("127.0.0.1".into());
 
         assert_eq!(client_conn.auth_challenge(), None);
         assert_eq!(client_conn.auth_pubkey(), None);
@@ -116,7 +116,7 @@ mod tests {
 
     #[test]
     fn test_fail_to_authenticate_with_invalid_event() {
-        let mut client_conn = ClientConn::new_with_default_settings("127.0.0.1".into());
+        let mut client_conn = ClientConn::new("127.0.0.1".into());
 
         assert_eq!(client_conn.auth_challenge(), None);
         assert_eq!(client_conn.auth_pubkey(), None);
@@ -137,7 +137,7 @@ mod tests {
 
     #[test]
     fn test_fail_to_authenticate_with_invalid_event_kind() {
-        let mut client_conn = ClientConn::new_with_default_settings("127.0.0.1".into());
+        let mut client_conn = ClientConn::new("127.0.0.1".into());
 
         assert_eq!(client_conn.auth_challenge(), None);
         assert_eq!(client_conn.auth_pubkey(), None);
@@ -157,7 +157,7 @@ mod tests {
 
     #[test]
     fn test_fail_to_authenticate_with_expired_timestamp() {
-        let mut client_conn = ClientConn::new_with_default_settings("127.0.0.1".into());
+        let mut client_conn = ClientConn::new("127.0.0.1".into());
 
         assert_eq!(client_conn.auth_challenge(), None);
         assert_eq!(client_conn.auth_pubkey(), None);
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn test_fail_to_authenticate_with_future_timestamp() {
-        let mut client_conn = ClientConn::new_with_default_settings("127.0.0.1".into());
+        let mut client_conn = ClientConn::new("127.0.0.1".into());
 
         assert_eq!(client_conn.auth_challenge(), None);
         assert_eq!(client_conn.auth_pubkey(), None);
@@ -197,7 +197,7 @@ mod tests {
 
     #[test]
     fn test_fail_to_authenticate_without_tags() {
-        let mut client_conn = ClientConn::new_with_default_settings("127.0.0.1".into());
+        let mut client_conn = ClientConn::new("127.0.0.1".into());
 
         assert_eq!(client_conn.auth_challenge(), None);
         assert_eq!(client_conn.auth_pubkey(), None);
@@ -216,7 +216,7 @@ mod tests {
 
     #[test]
     fn test_fail_to_authenticate_without_challenge() {
-        let mut client_conn = ClientConn::new_with_default_settings("127.0.0.1".into());
+        let mut client_conn = ClientConn::new("127.0.0.1".into());
 
         assert_eq!(client_conn.auth_challenge(), None);
         assert_eq!(client_conn.auth_pubkey(), None);
@@ -235,7 +235,7 @@ mod tests {
 
     #[test]
     fn test_fail_to_authenticate_without_relay() {
-        let mut client_conn = ClientConn::new_with_default_settings("127.0.0.1".into());
+        let mut client_conn = ClientConn::new("127.0.0.1".into());
 
         assert_eq!(client_conn.auth_challenge(), None);
         assert_eq!(client_conn.auth_pubkey(), None);
@@ -255,7 +255,7 @@ mod tests {
 
     #[test]
     fn test_fail_to_authenticate_with_invalid_challenge() {
-        let mut client_conn = ClientConn::new_with_default_settings("127.0.0.1".into());
+        let mut client_conn = ClientConn::new("127.0.0.1".into());
 
         assert_eq!(client_conn.auth_challenge(), None);
         assert_eq!(client_conn.auth_pubkey(), None);
@@ -274,7 +274,7 @@ mod tests {
 
     #[test]
     fn test_fail_to_authenticate_with_invalid_relay() {
-        let mut client_conn = ClientConn::new_with_default_settings("127.0.0.1".into());
+        let mut client_conn = ClientConn::new("127.0.0.1".into());
 
         assert_eq!(client_conn.auth_challenge(), None);
         assert_eq!(client_conn.auth_pubkey(), None);


### PR DESCRIPTION
This fix involves converting the passed ID to binary before using it in the SQL query to ensure proper handling of BLOB data types.

I also removed the unnecessary settings that were added to the connection file, as they are not needed.

Covers https://github.com/planetary-social/nostr-rs-relay/pull/4

This can be tested by running a relay with `docker compose up --build`, fetching any id and then trying:
`nak req -i $ID --force-pre-auth --sec $PERSONAL_SEC_KEY ws://localhost:8000`

